### PR TITLE
Adjust arguments to support excluding source files from analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,8 @@ test:
 	py.test -vv --cov=important tests/
 	important -v --requirements requirements.txt --constraints constraints.txt .
 
+coverage:
+	py.test -vv --cov=important --cov-report html tests/
+
 lint:
 	flake8 --ignore D .

--- a/README.rst
+++ b/README.rst
@@ -41,3 +41,12 @@ requirement while you phase it out) using:
     $ important -v --constraints constraints.txt .
     Error: Unused requirements or violated constraints found
     click<=1 (constraint violated by click==2)
+
+
+Check for unused requirements but exclude test files using:
+
+.. code:: bash
+
+    $ important -v --requirements requirements.txt **/test_*.py .
+    Error: Unused requirements or violated constraints found
+    caniusepython3 (unused requirement)

--- a/important/__main__.py
+++ b/important/__main__.py
@@ -1,5 +1,4 @@
 import click
-from click import ClickException
 import os
 from important.parse import parse_dir_imports, parse_file_imports, \
     parse_requirements
@@ -7,17 +6,17 @@ from important.check import check_unused_requirements, check_import_frequencies
 import sys
 
 
-@click.command('Check imports within sourcecode for either unused requirements'
-               ' or an import frequency that violates some constraints')
-@click.option('--requirements',
-              multiple=True,
+@click.command(help="Check imports within SOURCECODE (except those files "
+                    "provided in EXCLUDE) for either unused requirements or "
+                    "an import frequency that violates some constraints.")
+@click.option('--requirements', multiple=True,
               help="Requirement(s) file(s) to check for unused entries by "
                    "comparing against imports in source code; for formatting, "
                    "see pip's documentation https://pip.pypa.io/",
               type=click.Path(exists=True, file_okay=True, dir_okay=False,
                               writable=False, readable=True,
                               resolve_path=True))
-@click.option('--constraints',
+@click.option('--constraints', multiple=True,
               help="Requirement(s) file(s) to interpret as constraints on the "
                    "frequency of imports in source code.  Version numbers are "
                    "interpreted as frequency constraints, e.g., `os.path<5` "
@@ -25,36 +24,45 @@ import sys
                    "`os.path` module in the sourcecode.  Multiple constraints "
                    "can be added using commas, e.g. `os>=1,<=5` meaning that "
                    "sourcecode must contain one or more but 5 or less imports "
-                   "of `os`."
+                   "of `os`. "
                    "This can be used to slowly wean a project off of a module "
                    "(e.g. while converting a large project from Python 2 to 3)"
                    " or to prevent a module from being used altogether using "
-                   "`os.path==0`."
+                   "`os.path==0`. "
                    "Note that when frequency counting, imports of `os.path` "
                    "and `os` will produce a frequency of `os==2` and `os.path"
                    "==1`",
               type=click.Path(exists=True, file_okay=True, dir_okay=False,
                               writable=False, readable=True,
                               resolve_path=True))
-@click.option('-v', '--verbose', count=True)
-@click.argument('sourcecode', nargs=-1,
+@click.argument('exclude', nargs=-1,
                 type=click.Path(exists=True, file_okay=True, dir_okay=True,
                                 writable=False, readable=True,
                                 resolve_path=True))
-def check(requirements, constraints, verbose, sourcecode):
+@click.argument('sourcecode', nargs=1,
+                type=click.Path(exists=True, file_okay=True, dir_okay=True,
+                                writable=False, readable=True,
+                                resolve_path=True))
+@click.option('-v', '--verbose', count=True)
+def check(requirements, constraints, exclude, sourcecode, verbose):
     # Parse requirements and contraints
     parsed_requirements = []
     for requirements_path in requirements:
         parsed_requirements.extend(parse_requirements(requirements_path))
-    parsed_contraints = parse_requirements(constraints)
+    parsed_contraints = []
+    for contraints_path in constraints:
+        parsed_contraints.extend(parse_requirements(contraints_path))
 
     # Parse source code
-    imports = []
-    for path in sourcecode:
-        if os.path.isfile(path):
-            imports.extend(parse_file_imports(path))
-        elif os.path.isdir(path):
-            imports.extend(parse_dir_imports(path))
+    imports = None
+    if os.path.isfile(sourcecode):
+        imports = set(parse_file_imports(sourcecode, exclude))
+    elif os.path.isdir(sourcecode):
+        imports = set(parse_dir_imports(sourcecode, exclude))
+    else:
+        raise click.BadParameter("could not parse SOURCECODE '%s'; path is "
+                                 "either not a file or not a directory" %
+                                 sourcecode)
 
     output = []
 
@@ -84,12 +92,12 @@ def check(requirements, constraints, verbose, sourcecode):
             message = 'Unused requirements or violated constraints found'
             message += '\n' if output else ''
             message += '\n'.join(output) if output else ''
-            raise ClickException(message)
+            raise click.ClickException(message)
         else:
             sys.exit(1)
     if not requirements and not constraints:
-        raise ClickException('No checks performed; supply either requirements '
-                             'or contraints')
+        raise click.BadParameter('no checks performed; supply either '
+                                 '--requirements or --contraints')
 
 if __name__ == '__main__':
     check()

--- a/important/parse.py
+++ b/important/parse.py
@@ -1,9 +1,10 @@
 import ast
+from collections import namedtuple
 import os
 import pip
 from pip.req import parse_requirements as pip_parse_requirements
 import re
-from collections import namedtuple
+import stat
 
 RE_SHEBANG = re.compile('^#![^\n]*python[0-9]?$')
 
@@ -25,10 +26,28 @@ def _imports(source):
         yield statement
 
 
-def parse_file_imports(filepath, directory=None):
+def is_excluded(path, exclusions):
+    if exclusions:
+        generators = (
+            filter(lambda e: os.path.samefile(path, e), exclusions),
+            filter(lambda e: os.path.samefile(os.path.dirname(path), e),
+                   exclusions)
+        )
+        for generator in generators:
+            for _ in generator:
+                return True
+    return False
+
+
+def parse_file_imports(filepath, exclusions=None, directory=None):
+    # Skip if this file is supposed to be excluded
+    if is_excluded(filepath, exclusions):
+        return
+    # Create a directory to report filepaths relative to
     if directory is None:
         directory = os.path.dirname(filepath)
     display_filepath = os.path.relpath(filepath, directory)
+    # Compaile and parse abstract syntax tree and find import statements
     with open(filepath) as fh:
         source = fh.read()
     for statement in _imports(ast.parse(source, filename=filepath)):
@@ -37,21 +56,32 @@ def parse_file_imports(filepath, directory=None):
 
 
 def _is_script(filepath):
-    if os.access(filepath, os.X_OK):
-        with open(filepath, 'r') as fh:
-            first_line = fh.readline()
-        return bool(RE_SHEBANG.match(first_line))
+    if os.access(filepath, os.F_OK | os.R_OK | os.X_OK) and \
+       not stat.S_ISSOCK(os.stat(filepath).st_mode):
+        try:
+            with open(filepath, mode='r') as fh:
+                first_line = fh.readline()
+            return bool(RE_SHEBANG.match(first_line))
+        except UnicodeDecodeError:
+            pass  # Assume that this isn't a script
     return False
 
 
-def parse_dir_imports(current_directory, root_directory=None):
+def parse_dir_imports(current_directory, exclusions=None, root_directory=None):
+    # Skip if this directory is supposed to be excluded
+    if is_excluded(current_directory, exclusions):
+        return
+    # Create a directory to report filepaths relative to
     if root_directory is None:
         root_directory = current_directory
-    for root, _, files in os.walk(current_directory):
+    # Iterate over all Python/script files
+    for root, dirs, files in os.walk(current_directory, topdown=True):
+        dirs[:] = filter(lambda d: d not in exclusions,
+                         [os.path.join(root, d) for d in dirs])
         for filename in files:
             filepath = os.path.join(root, filename)
             if filename.endswith('.py') or _is_script(filepath):
-                for statement in parse_file_imports(filepath,
+                for statement in parse_file_imports(filepath, exclusions,
                                                     current_directory):
                     yield statement
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,7 @@ def python_source_file(tmpdir, python_source):
 
 
 @pytest.fixture
-def python_source_dir(tmpdir, python_source):
+def __python_source_dir__(tmpdir, python_source):
     executable_file_mode = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH \
         | stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
 
@@ -90,7 +90,32 @@ def python_source_dir(tmpdir, python_source):
     # Add file with shebang but wrong permissions that shouldn't be parsed
     python_source_dir.join('otherrandomfile').write(python_source)
 
-    return str(python_source_dir)
+    return python_source_dir
+
+
+@pytest.fixture
+def python_source_dir(__python_source_dir__):
+    return str(__python_source_dir__)
+
+
+@pytest.fixture
+def python_excluded_dir(__python_source_dir__):
+    # Create a directory intended to be excluded
+    python_excluded_dir = __python_source_dir__.mkdir('excluded')
+    python_excluded_dir.join('test4.py').write(python_source)
+    return str(python_excluded_dir)
+
+
+@pytest.fixture
+def python_excluded_file(__python_source_dir__):
+    python_excluded_file = __python_source_dir__.join('excluded.py')
+    python_excluded_file.write(python_source)
+    return str(python_excluded_file)
+
+
+@pytest.fixture
+def exclusions(python_excluded_file, python_excluded_dir):
+    return [python_excluded_file, python_excluded_dir]
 
 
 @pytest.fixture

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
-import pytest
-from important.__main__ import check
 from click.testing import CliRunner
+from important.__main__ import check
+import pytest
+import socket
 
 
 @pytest.fixture
@@ -8,34 +9,71 @@ def runner():
     return CliRunner()
 
 
-def test_main_verbose(runner, requirements_file, constraints_file,
-                      python_source_file, python_source_dir):
+def test_verbose(runner, requirements_file, constraints_file,
+                 python_source_dir, python_excluded_file, python_excluded_dir):
     result = runner.invoke(check, ['--requirements', requirements_file,
                                    '--constraints', constraints_file,
-                                   '--verbose',
-                                   python_source_file, python_source_dir])
+                                   '--verbose', python_excluded_file,
+                                   python_excluded_dir,
+                                   python_source_dir],
+                           catch_exceptions=False)
     assert result.exit_code == 1
     assert result.output == '''
 Error: Unused requirements or violated constraints found
 unused (unused requirement)
-os<6 (constraint violated by os==12)
-os.path<6 (constraint violated by os.path==8)
-re<=3,>1 (constraint violated by re==4)\n'''.lstrip()
+os<6 (constraint violated by os==9)
+os.path<6 (constraint violated by os.path==6)\n'''.lstrip()
 
 
-def test_main(runner, requirements_file, constraints_file, python_source_file,
-              python_source_dir):
+def test_dir(runner, requirements_file, constraints_file, python_source_dir,
+             python_excluded_file, python_excluded_dir):
     result = runner.invoke(check, ['--requirements', requirements_file,
                                    '--constraints', constraints_file,
-                                   python_source_file, python_source_dir])
+                                   python_excluded_file,
+                                   python_excluded_dir,
+                                   python_source_dir],
+                           catch_exceptions=False)
     assert result.exit_code == 1
     assert result.output == ''
 
 
-def test_main_insufficient_args(runner, requirements_file, constraints_file,
-                                python_source_file, python_source_dir):
-    result = runner.invoke(check, [python_source_file, python_source_dir])
+def test_main_file(runner, requirements_file, constraints_file,
+                   python_source_file):
+    result = runner.invoke(check, ['--requirements', requirements_file,
+                                   '--constraints', constraints_file,
+                                   python_source_file],
+                           catch_exceptions=False)
     assert result.exit_code == 1
-    assert result.output == '''
-Error: No checks performed; supply either requirements or contraints
-'''.lstrip()
+    assert result.output == ''
+
+
+def test_insufficient_args(runner, python_source_file):
+    result = runner.invoke(check, [python_source_file],
+                           catch_exceptions=False)
+    assert result.exit_code == 2
+    assert result.output == ('''
+Usage: check [OPTIONS] [EXCLUDE]... SOURCECODE
+
+Error: Invalid value: no checks performed; supply either --requirements '''
+                             '''or --contraints
+'''.lstrip())
+
+
+def test_socket(runner, tmpdir, requirements_file, constraints_file):
+    socket_file = tmpdir.join('s')
+    try:
+        python_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        python_socket.bind(str(socket_file))
+        result = runner.invoke(check, ['--requirements', requirements_file,
+                                       '--constraints', constraints_file,
+                                       str(socket_file)],
+                               catch_exceptions=False)
+        assert result.exit_code == 2
+        assert result.output == ('''
+Usage: check [OPTIONS] [EXCLUDE]... SOURCECODE
+
+Error: Invalid value: could not parse SOURCECODE '%s'; path is either not a '''
+                                 '''file or not a directory
+'''.lstrip() % str(socket_file))
+    finally:
+        python_socket.close()

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -7,15 +7,19 @@ def test_imports(python_source, python_imports):
     assert list(_imports(python_source)) == python_imports
 
 
-def test_file_imports(python_source_file, python_imports):
+def test_file_imports(python_source_file, python_imports, exclusions):
     assert list(parse_file_imports(python_source_file)) == \
         list(map(lambda i: Import(i[0], 'test.py', i[1], i[2]),
              python_imports))
 
 
-def test_dir_imports(tmpdir, python_source_dir, python_file_imports):
-    assert set(parse_dir_imports(python_source_dir)) == \
+def test_dir_imports(python_source_dir, python_file_imports, exclusions):
+    assert set(parse_dir_imports(python_source_dir, exclusions)) == \
         set(python_file_imports)
+
+
+def test_excluded_directory_imports(python_excluded_dir, exclusions):
+    assert set(parse_dir_imports(python_excluded_dir, exclusions)) == set()
 
 
 def test_re_shebang():


### PR DESCRIPTION
This PR adds support for ignoring files or directories when checking source code.  Specifically, it:
  - Changes arguments from accepting multiple source code paths to identify to accepting multiple source code paths to *exclude* followed by one source code path to analyze
  - Adds support for excluding paths when parsing directories
  - Makes script checking more robust (checks to ensure that a potential script file exists, can be read, executed, is not a socket file and if it is read that read problems result in assuming that a file is not a script)
  - Refactors main method tests