### PR TITLE
Translate requirements into package names

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,15 @@ Coming to pypi soon, but in the meantime, install from source using:
     $ cd important
     $ pip install .
 
+Requirements
+------------
+
+This works best when run from a virtualenv where your project's requirements
+are installed (to translate requirements to module names).
+
+This tool requires that it be installed with the same Python version as the
+source code that's analyzing and that the source code is syntactically correct.
+
 Usage
 -----
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,3 @@
-pip<=3
+pip<=4
 click<=3
 packaging<=1

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,3 +2,4 @@
 pytest
 pytest-cov
 flake8
+dnspython

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,6 @@ setup(
     },
     install_requires=['pip', 'click', 'packaging'],
     extras_require={
-        'test': ['pytest', 'pytest-cov', 'flake8'],
+        'test': ['pytest', 'pytest-cov', 'flake8', 'dnspython'],
     },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,10 +14,11 @@ def python_imports():
         ('time', 6, 0),
         ('sys', 6, 0),
         ('os.path', 7, 0),
-        ('os.path', 8, 0),
-        ('parser', 13, 4),
-        ('enum', 16, 4),
-        ('csv', 19, 8),
+        ('dns', 8, 0),
+        ('os.path', 9, 0),
+        ('parser', 14, 4),
+        ('enum', 17, 4),
+        ('csv', 20, 8),
     ]
 
 
@@ -44,6 +45,7 @@ import os
 import copy as duplicate
 import re, time, sys
 import os.path
+import dns
 from os.path import exists, join
 
 print("test")
@@ -122,10 +124,22 @@ def exclusions(python_excluded_file, python_excluded_dir):
 def requirements_file(tmpdir):
     requirements_file = tmpdir.join('requirements.txt')
     requirements_file.write('''
-unused
+pyyaml
 os
 csv
-parser'''.strip())
+parser
+dnspython'''.strip())
+    return str(requirements_file)
+
+
+@pytest.fixture
+def ok_requirements_file(tmpdir):
+    requirements_file = tmpdir.join('requirements.txt')
+    requirements_file.write('''
+os
+csv
+parser
+dnspython'''.strip())
     return str(requirements_file)
 
 
@@ -137,6 +151,22 @@ unused==0
 other_unused==0
 os<6
 os.path<6
+dnspython==0
+enum<10
+csv>1
+re>1,<=3'''.strip())
+    return str(constraints_file)
+
+
+@pytest.fixture
+def ok_constraints_file(tmpdir):
+    constraints_file = tmpdir.join('constraints.txt')
+    constraints_file.write('''
+unused==0
+other_unused==0
+os<=9
+os.path<=6
+dnspython<=6
 enum<10
 csv>1
 re>1,<=3'''.strip())

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -6,8 +6,8 @@ from important.check import check_unused_requirements, \
 
 def test_unused_requirements(python_file_imports, requirements_file):
     requirements = parse_requirements(requirements_file)
-    assert check_unused_requirements(python_file_imports, requirements) == \
-        set(['unused'])
+    assert set(check_unused_requirements(python_file_imports, requirements)) \
+        == set(['pyyaml'])
 
 
 def test_frequency_count_imports(python_file_imports):
@@ -15,6 +15,7 @@ def test_frequency_count_imports(python_file_imports):
         'collections': 3,
         'copy': 3,
         'csv': 3,
+        'dns': 3,
         'enum': 3,
         'math': 3,
         'os': 9,
@@ -31,4 +32,5 @@ def test_check_import_frequencies(python_file_imports, constraints_file):
     assert check_import_frequencies(python_file_imports, requirements) == {
         'os': (SpecifierSet('<6'), 9),
         'os.path': (SpecifierSet('<6'), 6),
+        'dnspython': (SpecifierSet('==0'), 3),
     }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,10 +19,87 @@ def test_verbose(runner, requirements_file, constraints_file,
                            catch_exceptions=False)
     assert result.exit_code == 1
     assert result.output == '''
+Parsed 39 imports in 3 files
 Error: Unused requirements or violated constraints found
-unused (unused requirement)
+pyyaml (unused requirement)
+dnspython==0 (constraint violated by dnspython==3)
 os<6 (constraint violated by os==9)
 os.path<6 (constraint violated by os.path==6)\n'''.lstrip()
+
+
+def test_dir_ok(runner, ok_requirements_file, ok_constraints_file,
+                python_source_dir, python_excluded_file, python_excluded_dir):
+    result = runner.invoke(check, ['--requirements', ok_requirements_file,
+                                   '--constraints', ok_constraints_file,
+                                   '--verbose', python_excluded_file,
+                                   python_excluded_dir,
+                                   python_source_dir],
+                           catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output == '''
+Parsed 39 imports in 3 files
+'''.lstrip()
+
+
+def test_dir_ok_verbose2(runner, ok_requirements_file, ok_constraints_file,
+                         python_source_dir, python_excluded_file,
+                         python_excluded_dir):
+    result = runner.invoke(check, ['--requirements', ok_requirements_file,
+                                   '--constraints', ok_constraints_file,
+                                   '-vv', python_excluded_file,
+                                   python_excluded_dir,
+                                   python_source_dir],
+                           catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output == '''
+Read requirements:
+os
+csv
+parser
+dnspython
+Read constraints:
+unused ==0
+other-unused ==0
+os <=9
+os.path <=6
+dnspython <=6
+enum <10
+csv >1
+re <=3,>1
+Parsed 39 imports in 3 files
+'''.lstrip()
+
+
+def test_dir_ok_verbose3(runner, ok_requirements_file, ok_constraints_file,
+                         python_source_dir, python_excluded_file,
+                         python_excluded_dir):
+    result = runner.invoke(check, ['--requirements', ok_requirements_file,
+                                   '--constraints', ok_constraints_file,
+                                   '-vvv', python_excluded_file,
+                                   python_excluded_dir,
+                                   python_source_dir],
+                           catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output == '''
+Read requirements:
+os
+csv
+parser
+dnspython
+Read constraints:
+unused ==0
+other-unused ==0
+os <=9
+os.path <=6
+dnspython <=6
+enum <10
+csv >1
+re <=3,>1
+Parsed 39 imports in 3 files
+scriptfile
+subdir/test3.py
+test1.py
+'''.lstrip()
 
 
 def test_dir(runner, requirements_file, constraints_file, python_source_dir,

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,6 +1,7 @@
 import pytest
 from important.parse import _imports, parse_file_imports, parse_dir_imports, \
-    parse_requirements, Import, RE_SHEBANG
+    parse_requirements, Import, RE_SHEBANG, \
+    translate_requirement_to_module_names
 
 
 def test_imports(python_source, python_imports):
@@ -69,3 +70,13 @@ def test_requirements_editable(tmpdir):
         list(parse_requirements(str(requirements_file)))
     assert str(excinfo.value) == \
         'Cannot parse SomeDependency: editable projects unsupported'
+
+
+def test_translate_requirement_to_module_names():
+    assert translate_requirement_to_module_names('click') == set(['click'])
+    assert translate_requirement_to_module_names('packaging') == \
+        set(['packaging'])
+    assert translate_requirement_to_module_names('pip') == set(['pip'])
+    assert translate_requirement_to_module_names('dnspython') == set(['dns'])
+    assert translate_requirement_to_module_names('fake') == set(['fake'])
+    assert translate_requirement_to_module_names('os.path') == set(['os.path'])


### PR DESCRIPTION
Fixes #7 by translating requirements into module names using locally installed versions of packages, inspecting their installed files, and guessing which of those could be top-level module names that could relate to module import statements.