### PR TITLE
Fix unused imports bug on packages providing multiple modules

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+branch = True
+
+[report]
+exclude_lines =
+    if __name__ == .__main__.:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
    - "3.3"
    - "3.4"
    - "3.5"
+   - "3.6"
 install:
   - make install
 script:

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,17 @@ install:
 	pip install -e .
 	pip install -r dev_requirements.txt
 
-test:
+test: install
 	py.test -vv --cov=important tests/
 	important -v --requirements requirements.txt --constraints constraints.txt .
 
 coverage:
 	py.test -vv --cov=important --cov-report html tests/
+
+autolint:
+	pip install autopep8
+	autopep8 --in-place --aggressive --aggressive *.py
+	autopep8 --in-place --aggressive --aggressive **/*.py
 
 lint:
 	flake8 --ignore D .

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,2 @@
 pip<=4
 click<=3
-packaging<=1

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,8 +1,9 @@
 -r requirements.txt
-pytest
+pytest>=2.7
 pytest-cov
 pytest-mock
 flake8
+mock
 
 # Modules tested
 dnspython       # Installed as directory `dns`

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -11,3 +11,5 @@ IPy             # Cased and installed as top-level Python file `IPy.py`
 numpy           # Has compiled C code; installed as a wheel
 pyyaml          # Installed as directory `yaml`
 beautifulsoup4  # Installed as directory `bs4`
+cssutils
+matplotlib

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -11,5 +11,5 @@ IPy             # Cased and installed as top-level Python file `IPy.py`
 numpy           # Has compiled C code; installed as a wheel
 pyyaml          # Installed as directory `yaml`
 beautifulsoup4  # Installed as directory `bs4`
-cssutils
-matplotlib
+cssutils        # Installs multiple top level modules
+matplotlib      # Installs multiple top level modules

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 pytest
 pytest-cov
+pytest-mock
 flake8
 
 # Modules tested

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,7 +4,8 @@ pytest-cov
 flake8
 
 # Modules tested
-dnspython       # Installed as directory dns
-IPy             # Cased and installed as top-level Python file
+dnspython       # Installed as directory `dns`
+IPy             # Cased and installed as top-level Python file `IPy.py`
 numpy           # Has compiled C code; installed as a wheel
-
+pyyaml          # Installed as directory `yaml`
+beautifulsoup4  # Installed as directory `bs4`

--- a/important/__main__.py
+++ b/important/__main__.py
@@ -106,7 +106,7 @@ def check(requirements, constraints, exclude, sourcecode, verbose):
         if verbose > 0:
             for module, violation in sorted(
                     contraint_violations.items(),
-                    key=lambda l: l[0]
+                    key=lambda module_violation: module_violation[0]
             ):
                 constraint, frequency = violation
                 output.append('%s%s (constraint violated by %s==%d)' %

--- a/important/__main__.py
+++ b/important/__main__.py
@@ -1,9 +1,14 @@
 import click
+import logging
 import os
+import sys
+
 from important.parse import parse_dir_imports, parse_file_imports, \
     parse_requirements
 from important.check import check_unused_requirements, check_import_frequencies
-import sys
+
+
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
 
 
 @click.command(help="Check imports within SOURCECODE (except those files "

--- a/important/__main__.py
+++ b/important/__main__.py
@@ -99,7 +99,10 @@ def check(requirements, constraints, exclude, sourcecode, verbose):
         contraint_violations = check_import_frequencies(imports,
                                                         parsed_contraints)
         if verbose > 0:
-            for module, violation in sorted(contraint_violations.items()):
+            for module, violation in sorted(
+                    contraint_violations.items(),
+                    key=lambda l: l[0]
+            ):
                 constraint, frequency = violation
                 output.append('%s%s (constraint violated by %s==%d)' %
                               (module, constraint, module, frequency))

--- a/important/__main__.py
+++ b/important/__main__.py
@@ -129,5 +129,6 @@ def check(requirements, constraints, exclude, sourcecode, verbose):
         else:
             sys.exit(1)
 
+
 if __name__ == '__main__':
     check()

--- a/important/check.py
+++ b/important/check.py
@@ -11,15 +11,18 @@ def check_unused_requirements(imports, requirements):
     imports = set(_base_module_name(import_statement)
                   for import_statement in imports)
     requirements = set(requirement.name for requirement in requirements)
+    # Translate package names into module names that can be imported
     module_requirements = {}
-    all_modules = set()
     for requirement in requirements:
         modules = translate_requirement_to_module_names(requirement)
         for module in modules:
             module_requirements[module] = requirement
-        all_modules |= modules
-    unused_modules = all_modules - imports
-    return set(map(lambda module: module_requirements[module], unused_modules))
+    # Translate imported modules into package names
+    imports_as_requirements = set(
+        (module_requirements.get(module, module) for module in imports)
+    )
+    # Find those required packages that were not imported
+    return requirements - imports_as_requirements
 
 
 def frequency_count_imports(imports):

--- a/important/parse.py
+++ b/important/parse.py
@@ -14,6 +14,8 @@ RE_SHEBANG = re.compile('^#![^\n]*python[0-9]?$')
 
 Import = namedtuple('Import', ['module', 'filename', 'lineno', 'col_offset'])
 
+logger = logging.getLogger()
+
 
 def _imports(source):
     def _ast_imports(root):
@@ -60,7 +62,7 @@ def parse_file_imports(filepath, exclusions=None, directory=None):
             module, lineno, col_offset = statement
             yield Import(module, display_filepath, lineno, col_offset)
     except SyntaxError as e:
-        logging.warning('Skipping {filename} due to syntax error: {error}'
+        logger.warning('Skipping {filename} due to syntax error: {error}'
                         .format(filename=e.filename, error=str(e)))
 
 
@@ -136,4 +138,10 @@ def translate_requirement_to_module_names(requirement_name):
             top_level_files = filter(is_top_level_file, result['files'])
             provides |= set([os.path.splitext(filename)[0]
                              for filename in top_level_files])
+
+    if provides:
+        return provides
+    else:
+        logger.warning("Cannot find installation files for requirement '{requirement}'; please install this package for more accurate name resolution".format(requirement=requirement_name))
+            
     return provides if provides else set([requirement_name])

--- a/important/parse.py
+++ b/important/parse.py
@@ -60,8 +60,8 @@ def parse_file_imports(filepath, exclusions=None, directory=None):
             module, lineno, col_offset = statement
             yield Import(module, display_filepath, lineno, col_offset)
     except SyntaxError as e:
-        logging.warning('Skipping {filename} due to syntax error: {error}'.format(
-                        filename=e.filename, error=str(e)))
+        logging.warning('Skipping {filename} due to syntax error: {error}'
+                        .format(filename=e.filename, error=str(e)))
 
 
 def _is_script(filepath):

--- a/setup.py
+++ b/setup.py
@@ -34,4 +34,5 @@ setup(
             'important = important.__main__:check',
         ],
     },
+    install_requires=['pip', 'click'],
 )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     keywords=['import', 'requirement', 'unused'],
     packages=['important'],
@@ -32,9 +33,5 @@ setup(
         'console_scripts': [
             'important = important.__main__:check',
         ],
-    },
-    install_requires=['pip', 'click', 'packaging'],
-    extras_require={
-        'test': ['pytest', 'pytest-cov', 'flake8', 'dnspython'],
     },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,9 @@ IMPORT_STATEMENT_TO_IMPORT = {
     'import numpy as np': 'numpy',
     'import yaml': 'yaml',
     'from bs4 import BeautifulSoup': 'bs4',
+    'import pylab': 'pylab',
+    'import matplotlib.pyplot as plt': 'matplotlib.pyplot',
+    'import cssutils': 'cssutils',
 }
 
 IMPORT_TO_PACKAGE = {
@@ -21,6 +24,10 @@ IMPORT_TO_PACKAGE = {
     'numpy': 'numpy',  # package with C extensions
     'yaml': 'pyyaml',  # package installed with differing name
     'bs4': 'beautifulsoup4',  # package installed with differing name
+    'matplotlib': 'matplotlib',
+    'cssutils': 'cssutils',
+    'pylab': 'matplotlib',
+    'matplotlib.pyplot': 'matplotlib'
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,14 @@ def python_source_file(tmpdir, python_source):
 
 
 @pytest.fixture
+def binary_file(tmpdir):
+    binary_file = tmpdir.join('bad')
+    with open(str(binary_file), 'wb') as fh:
+        fh.write(bytearray.fromhex('FFFF FFFF'))
+    return str(binary_file)
+
+
+@pytest.fixture
 def __python_source_dir__(tmpdir, python_source):
     executable_file_mode = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH \
         | stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,11 +15,12 @@ IMPORT_STATEMENT_TO_IMPORT = {
 }
 
 IMPORT_TO_PACKAGE = {
-    'dns': 'dnspython',   # package installed with differing name ('dns' folder)
+    # package installed with differing name ('dns' folder)
+    'dns': 'dnspython',
     'IPy': 'IPy',  # case sensitive package name installed as file ('IPy.py')
     'numpy': 'numpy',  # package with C extensions
     'yaml': 'pyyaml',  # package installed with differing name
-    'bs4': 'beautifulsoup4',  #  package installed with differing name
+    'bs4': 'beautifulsoup4',  # package installed with differing name
 }
 
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -4,9 +4,12 @@ from important.check import check_unused_requirements, \
     frequency_count_imports, check_import_frequencies
 
 
-def test_unused_requirements(python_file_imports, requirements_file_one_unused):
+def test_unused_requirements(
+        python_file_imports,
+        requirements_file_one_unused):
     requirements = parse_requirements(requirements_file_one_unused)
-    unused_requirements = check_unused_requirements(python_file_imports, requirements)
+    unused_requirements = check_unused_requirements(
+        python_file_imports, requirements)
     assert set(unused_requirements) == {'unused'}
 
 
@@ -27,7 +30,10 @@ def test_frequency_count_imports(python_file_imports, import_name):
     }
 
 
-def test_check_import_frequencies(python_file_imports, constraints_file_package_disallowed, package_name):
+def test_check_import_frequencies(
+        python_file_imports,
+        constraints_file_package_disallowed,
+        package_name):
     requirements = parse_requirements(constraints_file_package_disallowed)
     assert check_import_frequencies(python_file_imports, requirements) == {
         'os': (SpecifierSet('<6'), 9),

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,7 +1,7 @@
-from pip._vendor.packaging.specifiers import SpecifierSet
 from important.parse import parse_requirements
 from important.check import check_unused_requirements, \
     frequency_count_imports, check_import_frequencies
+from pip._vendor.packaging.specifiers import SpecifierSet
 
 
 def test_unused_requirements(python_file_imports,

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -4,9 +4,8 @@ from important.check import check_unused_requirements, \
     frequency_count_imports, check_import_frequencies
 
 
-def test_unused_requirements(
-        python_file_imports,
-        requirements_file_one_unused):
+def test_unused_requirements(python_file_imports,
+                             requirements_file_one_unused):
     requirements = parse_requirements(requirements_file_one_unused)
     unused_requirements = check_unused_requirements(
         python_file_imports, requirements)
@@ -14,7 +13,7 @@ def test_unused_requirements(
 
 
 def test_frequency_count_imports(python_file_imports, import_name):
-    assert frequency_count_imports(python_file_imports) == {
+    expected = {
         import_name: 3,
         'collections': 3,
         'copy': 6,
@@ -28,6 +27,13 @@ def test_frequency_count_imports(python_file_imports, import_name):
         'sys': 3,
         'time': 3
     }
+    # Also expect shorter forms of submodules (e.g. for `os.path` also
+    # expect `os`)
+    if '.' in import_name:
+        for dots in range(1, import_name.count('.') + 1):
+            new_import_name = '.'.join(import_name.split('.')[:dots])
+            expected[new_import_name] = 3
+    assert frequency_count_imports(python_file_imports) == expected
 
 
 def test_check_import_frequencies(

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -4,22 +4,20 @@ from important.check import check_unused_requirements, \
     frequency_count_imports, check_import_frequencies
 
 
-def test_unused_requirements(python_file_imports, requirements_file):
-    requirements = parse_requirements(requirements_file)
-    assert set(check_unused_requirements(python_file_imports, requirements)) \
-        == set(['pyyaml'])
+def test_unused_requirements(python_file_imports, requirements_file_one_unused):
+    requirements = parse_requirements(requirements_file_one_unused)
+    unused_requirements = check_unused_requirements(python_file_imports, requirements)
+    assert set(unused_requirements) == {'unused'}
 
 
-def test_frequency_count_imports(python_file_imports):
+def test_frequency_count_imports(python_file_imports, import_name):
     assert frequency_count_imports(python_file_imports) == {
-        'IPy': 3,
+        import_name: 3,
         'collections': 3,
-        'copy': 3,
+        'copy': 6,
         'csv': 3,
-        'dns': 3,
         'enum': 3,
         'math': 3,
-        'numpy': 3,
         'os': 9,
         'os.path': 6,
         'parser': 3,
@@ -29,10 +27,10 @@ def test_frequency_count_imports(python_file_imports):
     }
 
 
-def test_check_import_frequencies(python_file_imports, constraints_file):
-    requirements = parse_requirements(constraints_file)
+def test_check_import_frequencies(python_file_imports, constraints_file_package_disallowed, package_name):
+    requirements = parse_requirements(constraints_file_package_disallowed)
     assert check_import_frequencies(python_file_imports, requirements) == {
         'os': (SpecifierSet('<6'), 9),
         'os.path': (SpecifierSet('<6'), 6),
-        'dnspython': (SpecifierSet('==0'), 3),
+        package_name: (SpecifierSet('==0'), 3),
     }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,6 +29,7 @@ def run_check(requirements=None, constraints=None, verbose=0, files=None):
 def format_output(*output, **kwargs):
     package_name = kwargs.get('package_name')
     import_name = kwargs.get('import_name')
+
     def sort_output(output, package_name):
         """ Format and sort output by requirement/constraint package names """
         if package_name and package_name in output or \
@@ -41,6 +42,7 @@ def format_output(*output, **kwargs):
             )
         else:
             return output
+
     return '\n'.join(
         (sort_output(
             output=part.strip().format(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,4 @@
 import os
-import pytest
 import re
 import socket
 import tempfile
@@ -31,7 +30,7 @@ def format_output(*output, package_name=None, import_name=None):
     def sort_output(output, package_name):
         """ Format and sort output by requirement/constraint package names """
         if package_name and package_name in output or \
-           import_name and  import_name in output:
+           import_name and import_name in output:
             return '\n'.join(
                 sorted(
                     output.strip().split('\n'),
@@ -41,13 +40,11 @@ def format_output(*output, package_name=None, import_name=None):
         else:
             return output
     return '\n'.join(
-        (
-            sort_output(
-                output=part.strip().format(package_name=package_name, import_name=import_name),
-                package_name=package_name
-            ) for part in output
-        )
-    ) + '\n'    
+        (sort_output(
+            output=part.strip().format(
+                package_name=package_name,
+                import_name=import_name),
+            package_name=package_name) for part in output)) + '\n'
 
 
 def test_main_verbosity_level_0(requirements_file, constraints_file,
@@ -119,7 +116,6 @@ Parsed 42 imports in 3 files
 ''', package_name=package_name)
 
 
-
 def test_main_verbosity_level_3(requirements_file, constraints_file,
                                 python_source_dir, python_excluded_file,
                                 python_excluded_dir, package_name,
@@ -153,7 +149,7 @@ unused==0''', '''
 Parsed 42 imports in 3 files
 scriptfile
 subdir/test3.py
-test1.py''','''
+test1.py''', '''
 {import_name}=scriptfile:7
 {import_name}=subdir/test3.py:7
 {import_name}=test1.py:7
@@ -199,10 +195,13 @@ time=test1.py:8
 ''', package_name=package_name, import_name=import_name)
 
 
-def test_main_error_verbosity_level_0(requirements_file_one_unused,
-                            constraints_file_package_disallowed,
-                            python_source_dir, python_excluded_file, python_excluded_dir,
-                            package_name):
+def test_main_error_verbosity_level_0(
+        requirements_file_one_unused,
+        constraints_file_package_disallowed,
+        python_source_dir,
+        python_excluded_file,
+        python_excluded_dir,
+        package_name):
     result = run_check(
         requirements=requirements_file_one_unused,
         constraints=constraints_file_package_disallowed,
@@ -215,7 +214,6 @@ def test_main_error_verbosity_level_0(requirements_file_one_unused,
     )
     assert result.exit_code == 1
     assert result.output == ''
-
 
 
 def test_main_error_verbosity_level_1(requirements_file_one_unused,
@@ -237,12 +235,11 @@ def test_main_error_verbosity_level_1(requirements_file_one_unused,
         '''
 Parsed 42 imports in 3 files
 Error: Unused requirements or violated constraints found
-unused (unused requirement)''','''
+unused (unused requirement)''', '''
 {package_name}==0 (constraint violated by {package_name}==3)
 os<6 (constraint violated by os==9)
 os.path<6 (constraint violated by os.path==6)''',
         package_name=package_name)
-
 
 
 def test_main_error_just_dir(requirements_file_one_unused,
@@ -261,7 +258,7 @@ def test_main_error_just_dir(requirements_file_one_unused,
         '''
 Parsed 42 imports in 3 files
 Error: Unused requirements or violated constraints found
-unused (unused requirement)''','''
+unused (unused requirement)''', '''
 {package_name}==0 (constraint violated by {package_name}==3)
 os<6 (constraint violated by os==9)
 os.path<6 (constraint violated by os.path==6)''',
@@ -269,8 +266,8 @@ os.path<6 (constraint violated by os.path==6)''',
 
 
 def test_main_error_just_file(requirements_file_one_unused,
-                             constraints_file_package_disallowed,
-                             python_source_file, package_name):
+                              constraints_file_package_disallowed,
+                              python_source_file, package_name):
     result = run_check(
         requirements=requirements_file_one_unused,
         constraints=constraints_file_package_disallowed,
@@ -284,13 +281,13 @@ def test_main_error_just_file(requirements_file_one_unused,
         '''
 Parsed 14 imports in 1 files
 Error: Unused requirements or violated constraints found
-unused (unused requirement)''','''
+unused (unused requirement)''', '''
 {package_name}==0 (constraint violated by {package_name}==1)
 csv>1 (constraint violated by csv==1)
 re<=3,>1 (constraint violated by re==1)
 ''', package_name=package_name)
 
-    
+
 def test_insufficient_args(python_source_file):
     result = run_check(
         files=[

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -26,7 +26,9 @@ def run_check(requirements=None, constraints=None, verbose=0, files=None):
     return CliRunner().invoke(check, runner_args, catch_exceptions=False)
 
 
-def format_output(*output, package_name=None, import_name=None):
+def format_output(*output, **kwargs):
+    package_name = kwargs.get('package_name')
+    import_name = kwargs.get('import_name')
     def sort_output(output, package_name):
         """ Format and sort output by requirement/constraint package names """
         if package_name and package_name in output or \

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,181 +1,302 @@
+import os
+import pytest
+import re
+import socket
+import tempfile
+
 from click.testing import CliRunner
 from important.__main__ import check
-import pytest
-import socket
 
 
-@pytest.fixture
-def runner():
-    return CliRunner()
+def run_check(requirements=None, constraints=None, verbose=0, files=None):
+    runner_args = []
+    if requirements:
+        runner_args.extend([
+            '--requirements', requirements
+        ])
+    if constraints:
+        runner_args.extend([
+            '--constraints', constraints
+        ])
+    if verbose:
+        runner_args.extend([
+            '-' + verbose * 'v'
+        ])
+    if files:
+        runner_args.extend(files)
+    return CliRunner().invoke(check, runner_args, catch_exceptions=False)
 
 
-def test_verbose(runner, requirements_file, constraints_file,
-                 python_source_dir, python_excluded_file, python_excluded_dir):
-    result = runner.invoke(check, ['--requirements', requirements_file,
-                                   '--constraints', constraints_file,
-                                   '--verbose', python_excluded_file,
-                                   python_excluded_dir,
-                                   python_source_dir],
-                           catch_exceptions=False)
-    assert result.exit_code == 1
+def format_output(*output, package_name=None, import_name=None):
+    def sort_output(output, package_name):
+        """ Format and sort output by requirement/constraint package names """
+        if package_name and package_name in output or \
+           import_name and  import_name in output:
+            return '\n'.join(
+                sorted(
+                    output.strip().split('\n'),
+                    key=lambda l: re.split('[\<\>\= ]+', l, maxsplit=1)[0]
+                )
+            )
+        else:
+            return output
+    return '\n'.join(
+        (
+            sort_output(
+                output=part.strip().format(package_name=package_name, import_name=import_name),
+                package_name=package_name
+            ) for part in output
+        )
+    ) + '\n'    
+
+
+def test_main_verbosity_level_0(requirements_file, constraints_file,
+                                python_source_dir, python_excluded_file,
+                                python_excluded_dir):
+    result = run_check(
+        requirements=requirements_file,
+        constraints=constraints_file,
+        verbose=0,
+        files=[
+            python_excluded_file,
+            python_excluded_dir,
+            python_source_dir
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output == ''
+
+
+def test_main_verbosity_level_1(requirements_file, constraints_file,
+                                python_source_dir, python_excluded_file,
+                                python_excluded_dir):
+    result = run_check(
+        requirements=requirements_file,
+        constraints=constraints_file,
+        verbose=1,
+        files=[
+            python_excluded_file,
+            python_excluded_dir,
+            python_source_dir
+        ]
+    )
+    assert result.exit_code == 0, result.output
     assert result.output == '''
-Parsed 45 imports in 3 files
-Error: Unused requirements or violated constraints found
-pyyaml (unused requirement)
-dnspython==0 (constraint violated by dnspython==3)
-os<6 (constraint violated by os==9)
-os.path<6 (constraint violated by os.path==6)\n'''.lstrip()
-
-
-def test_dir_ok(runner, ok_requirements_file, ok_constraints_file,
-                python_source_dir, python_excluded_file, python_excluded_dir):
-    result = runner.invoke(check, ['--requirements', ok_requirements_file,
-                                   '--constraints', ok_constraints_file,
-                                   '--verbose', python_excluded_file,
-                                   python_excluded_dir,
-                                   python_source_dir],
-                           catch_exceptions=False)
-    assert result.exit_code == 0
-    assert result.output == '''
-Parsed 45 imports in 3 files
+Parsed 42 imports in 3 files
 '''.lstrip()
 
 
-def test_dir_ok_verbose2(runner, ok_requirements_file, ok_constraints_file,
-                         python_source_dir, python_excluded_file,
-                         python_excluded_dir):
-    result = runner.invoke(check, ['--requirements', ok_requirements_file,
-                                   '--constraints', ok_constraints_file,
-                                   '-vv', python_excluded_file,
-                                   python_excluded_dir,
-                                   python_source_dir],
-                           catch_exceptions=False)
-    assert result.exit_code == 0
-    assert result.output == '''
-Read requirements:
-IPy
+def test_main_verbosity_level_2(requirements_file, constraints_file,
+                                python_source_dir, python_excluded_file,
+                                python_excluded_dir, package_name):
+    result = run_check(
+        requirements=requirements_file,
+        constraints=constraints_file,
+        verbose=2,
+        files=[
+            python_excluded_file,
+            python_excluded_dir,
+            python_source_dir
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output == format_output('''
+Read requirements:''', '''
 csv
-dnspython
-numpy
 os
 parser
-Read constraints:
+{package_name}''', '''
+Read constraints:''', '''
 csv>1
-dnspython<=6
+{package_name}<=6
 enum<10
 os<=9
 os.path<=6
 other-unused==0
 re<=3,>1
-unused==0
-Parsed 45 imports in 3 files
-'''.lstrip()
+unused==0''', '''
+Parsed 42 imports in 3 files
+''', package_name=package_name)
 
 
-def test_dir_ok_verbose3(runner, ok_requirements_file, ok_constraints_file,
-                         python_source_dir, python_excluded_file,
-                         python_excluded_dir):
-    result = runner.invoke(check, ['--requirements', ok_requirements_file,
-                                   '--constraints', ok_constraints_file,
-                                   '-vvv', python_excluded_file,
-                                   python_excluded_dir,
-                                   python_source_dir],
-                           catch_exceptions=False)
-    assert result.exit_code == 0
-    assert result.output == '''
-Read requirements:
-IPy
+
+def test_main_verbosity_level_3(requirements_file, constraints_file,
+                                python_source_dir, python_excluded_file,
+                                python_excluded_dir, package_name,
+                                import_name):
+    result = run_check(
+        requirements=requirements_file,
+        constraints=constraints_file,
+        verbose=3,
+        files=[
+            python_excluded_file,
+            python_excluded_dir,
+            python_source_dir
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output == format_output('''
+Read requirements:''', '''
 csv
-dnspython
-numpy
 os
 parser
-Read constraints:
+{package_name}''', '''
+Read constraints:''', '''
 csv>1
-dnspython<=6
+{package_name}<=6
 enum<10
 os<=9
 os.path<=6
 other-unused==0
 re<=3,>1
-unused==0
-Parsed 45 imports in 3 files
+unused==0''', '''
+Parsed 42 imports in 3 files
 scriptfile
 subdir/test3.py
-test1.py
-IPy=scriptfile:10
-IPy=subdir/test3.py:10
-IPy=test1.py:10
+test1.py''','''
+{import_name}=scriptfile:7
+{import_name}=subdir/test3.py:7
+{import_name}=test1.py:7
 collections=scriptfile:2
 collections=subdir/test3.py:2
 collections=test1.py:2
 copy=scriptfile:5
+copy=scriptfile:6
 copy=subdir/test3.py:5
+copy=subdir/test3.py:6
 copy=test1.py:5
-csv=scriptfile:22
-csv=subdir/test3.py:22
-csv=test1.py:22
-dns=scriptfile:8
-dns=subdir/test3.py:8
-dns=test1.py:8
-enum=scriptfile:19
-enum=subdir/test3.py:19
-enum=test1.py:19
+copy=test1.py:6
+csv=scriptfile:21
+csv=subdir/test3.py:21
+csv=test1.py:21
+enum=scriptfile:18
+enum=subdir/test3.py:18
+enum=test1.py:18
 math=scriptfile:3
 math=subdir/test3.py:3
 math=test1.py:3
-numpy=scriptfile:11
-numpy=subdir/test3.py:11
-numpy=test1.py:11
 os=scriptfile:4
 os=subdir/test3.py:4
 os=test1.py:4
-os.path=scriptfile:7
 os.path=scriptfile:9
-os.path=subdir/test3.py:7
+os.path=scriptfile:10
 os.path=subdir/test3.py:9
-os.path=test1.py:7
+os.path=subdir/test3.py:10
 os.path=test1.py:9
-parser=scriptfile:16
-parser=subdir/test3.py:16
-parser=test1.py:16
-re=scriptfile:6
-re=subdir/test3.py:6
-re=test1.py:6
-sys=scriptfile:6
-sys=subdir/test3.py:6
-sys=test1.py:6
-time=scriptfile:6
-time=subdir/test3.py:6
-time=test1.py:6
-'''.lstrip()
+os.path=test1.py:10
+parser=scriptfile:15
+parser=subdir/test3.py:15
+parser=test1.py:15
+re=scriptfile:8
+re=subdir/test3.py:8
+re=test1.py:8
+sys=scriptfile:8
+sys=subdir/test3.py:8
+sys=test1.py:8
+time=scriptfile:8
+time=subdir/test3.py:8
+time=test1.py:8
+''', package_name=package_name, import_name=import_name)
 
 
-def test_dir(runner, requirements_file, constraints_file, python_source_dir,
-             python_excluded_file, python_excluded_dir):
-    result = runner.invoke(check, ['--requirements', requirements_file,
-                                   '--constraints', constraints_file,
-                                   python_excluded_file,
-                                   python_excluded_dir,
-                                   python_source_dir],
-                           catch_exceptions=False)
+def test_main_error_verbosity_level_0(requirements_file_one_unused,
+                            constraints_file_package_disallowed,
+                            python_source_dir, python_excluded_file, python_excluded_dir,
+                            package_name):
+    result = run_check(
+        requirements=requirements_file_one_unused,
+        constraints=constraints_file_package_disallowed,
+        verbose=0,
+        files=[
+            python_excluded_file,
+            python_excluded_dir,
+            python_source_dir
+        ]
+    )
     assert result.exit_code == 1
     assert result.output == ''
 
 
-def test_main_file(runner, requirements_file, constraints_file,
-                   python_source_file):
-    result = runner.invoke(check, ['--requirements', requirements_file,
-                                   '--constraints', constraints_file,
-                                   python_source_file],
-                           catch_exceptions=False)
+
+def test_main_error_verbosity_level_1(requirements_file_one_unused,
+                                      constraints_file_package_disallowed,
+                                      python_source_dir, python_excluded_file,
+                                      python_excluded_dir, package_name):
+    result = run_check(
+        requirements=requirements_file_one_unused,
+        constraints=constraints_file_package_disallowed,
+        verbose=1,
+        files=[
+            python_excluded_file,
+            python_excluded_dir,
+            python_source_dir
+        ]
+    )
     assert result.exit_code == 1
-    assert result.output == ''
+    assert result.output == format_output(
+        '''
+Parsed 42 imports in 3 files
+Error: Unused requirements or violated constraints found
+unused (unused requirement)''','''
+{package_name}==0 (constraint violated by {package_name}==3)
+os<6 (constraint violated by os==9)
+os.path<6 (constraint violated by os.path==6)''',
+        package_name=package_name)
 
 
-def test_insufficient_args(runner, python_source_file):
-    result = runner.invoke(check, [python_source_file],
-                           catch_exceptions=False)
+
+def test_main_error_just_dir(requirements_file_one_unused,
+                             constraints_file_package_disallowed,
+                             python_source_dir, package_name):
+    result = run_check(
+        requirements=requirements_file_one_unused,
+        constraints=constraints_file_package_disallowed,
+        verbose=1,
+        files=[
+            python_source_dir
+        ]
+    )
+    assert result.exit_code == 1
+    assert result.output == format_output(
+        '''
+Parsed 42 imports in 3 files
+Error: Unused requirements or violated constraints found
+unused (unused requirement)''','''
+{package_name}==0 (constraint violated by {package_name}==3)
+os<6 (constraint violated by os==9)
+os.path<6 (constraint violated by os.path==6)''',
+        package_name=package_name)
+
+
+def test_main_error_just_file(requirements_file_one_unused,
+                             constraints_file_package_disallowed,
+                             python_source_file, package_name):
+    result = run_check(
+        requirements=requirements_file_one_unused,
+        constraints=constraints_file_package_disallowed,
+        verbose=1,
+        files=[
+            python_source_file
+        ]
+    )
+    assert result.exit_code == 1
+    assert result.output == format_output(
+        '''
+Parsed 14 imports in 1 files
+Error: Unused requirements or violated constraints found
+unused (unused requirement)''','''
+{package_name}==0 (constraint violated by {package_name}==1)
+csv>1 (constraint violated by csv==1)
+re<=3,>1 (constraint violated by re==1)
+''', package_name=package_name)
+
+    
+def test_insufficient_args(python_source_file):
+    result = run_check(
+        files=[
+            python_source_file
+        ]
+    )
     assert result.exit_code == 2
     assert result.output == ('''
 Usage: check [OPTIONS] [EXCLUDE]... SOURCECODE
@@ -185,15 +306,20 @@ Error: Invalid value: no checks performed; supply either --requirements '''
 '''.lstrip())
 
 
-def test_socket(runner, tmpdir, requirements_file, constraints_file):
-    socket_file = tmpdir.join('s')
+def test_socket(requirements_file, constraints_file):
+    # Make our own temp dir because tmpdir's are too long to be unix sockets
+    tempdir = tempfile.mkdtemp()
+    socket_file = os.path.realpath(os.path.join(tempdir, 's'))
     try:
         python_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         python_socket.bind(str(socket_file))
-        result = runner.invoke(check, ['--requirements', requirements_file,
-                                       '--constraints', constraints_file,
-                                       str(socket_file)],
-                               catch_exceptions=False)
+        result = run_check(
+            requirements=requirements_file,
+            constraints=constraints_file,
+            files=[
+                str(socket_file)
+            ]
+        )
         assert result.exit_code == 2
         assert result.output == ('''
 Usage: check [OPTIONS] [EXCLUDE]... SOURCECODE
@@ -203,3 +329,5 @@ Error: Invalid value: could not parse SOURCECODE '%s'; path is either not a '''
 '''.lstrip() % str(socket_file))
     finally:
         python_socket.close()
+        os.remove(socket_file)
+        os.rmdir(tempdir)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -3,7 +3,11 @@ import pytest
 from important.parse import _imports, parse_file_imports, parse_dir_imports, \
     parse_requirements, Import, RE_SHEBANG, \
     translate_requirement_to_module_names
-from unittest.mock import Mock
+
+try:
+    from unittest.mock import Mock
+except:
+    from mock import Mock
 
 
 def test_imports(python_source, python_imports):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -11,7 +11,7 @@ def test_imports(python_source, python_imports):
 def test_file_imports(python_source_file, python_imports, exclusions):
     assert list(parse_file_imports(python_source_file)) == \
         list(map(lambda i: Import(i[0], 'test.py', i[1], i[2]),
-             python_imports))
+                 python_imports))
 
 
 def test_dir_imports(python_source_dir, python_file_imports, exclusions):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,7 +1,10 @@
+import os
 import pytest
+import stat
+import sys
 
 from important.parse import _imports, parse_file_imports, parse_dir_imports, \
-    parse_requirements, Import, RE_SHEBANG, \
+    parse_requirements, Import, RE_SHEBANG, _is_script, \
     translate_requirement_to_module_names
 
 try:
@@ -9,15 +12,67 @@ try:
 except:
     from mock import Mock
 
+ENCODING = 'utf-8' if sys.version_info > (3, 0) else 'utf8'
+
 
 def test_imports(python_source, python_imports):
     assert list(_imports(python_source)) == python_imports
 
 
-def test_file_imports(python_source_file, python_imports, exclusions):
+def test_file_imports(python_source_file, python_imports):
     assert list(parse_file_imports(python_source_file)) == \
         list(map(lambda i: Import(i[0], 'test.py', i[1], i[2]),
                  python_imports))
+
+
+def test_file_imports_with_syntax_error(mocker, python_source_file):
+    logger = Mock()
+    mocker.patch('important.parse.logger', logger)
+
+    # Alter file so that it won't compile
+    with open(python_source_file, 'a') as fh:
+        fh.write('not a valid Python statement')
+
+    # Attempt to parse and assert that it logged a warning
+    list(parse_file_imports(python_source_file))
+    logger.warning.assert_called_with(
+        'Skipping {filename} due to syntax error: {error}'.format(
+            filename=python_source_file,
+            error='invalid syntax (test.py, line 21)'
+        )
+    )
+
+
+def test_file_imports_binary_file(mocker, binary_file):
+    logger = Mock()
+    mocker.patch('important.parse.logger', logger)
+
+    # Attempt to parse and assert that it logged a warning
+    list(parse_file_imports(binary_file))
+    logger.warning.assert_called_with(
+        'Skipping {filename} due to decoding error: {error}'.format(
+            filename=binary_file,
+            error="'{encoding}' codec can't decode byte 0xff in position 0:\
+ invalid start byte".format(encoding=ENCODING)
+        )
+    )
+
+
+def test_is_script_binary_file(mocker, binary_file):
+    logger = Mock()
+    mocker.patch('important.parse.logger', logger)
+
+    # Make the file executable to appear to be a script
+    os.chmod(binary_file, stat.S_IXUSR | stat.S_IRUSR)
+    # Attempt to parse and assert that it logged a warning
+    _is_script(binary_file)
+    logger.warning.assert_called_with(
+        'Skipping {filename} due to decoding error: {error}'.format(
+            filename=binary_file,
+            error="'{encoding}' codec can't decode byte 0xff in position 0:\
+ invalid start byte".format(encoding=ENCODING)
+        )
+    )
 
 
 def test_dir_imports(python_source_dir, python_file_imports, exclusions):


### PR DESCRIPTION
Fixes #10.

#### Problem
Unused dependencies were being incorrectly calculated when a package provides multiple modules (those additional modules were erroneously being listed as unused).

#### Solution
Refactored to make it easier to test specific import statements and then altered code to now compare sets of requirements versus sets of imports converted into requirements to detect which are unused.

#### Additional changes
- Python 3.6 compatibility
- Warnings added when a file can't be parsed
- Added autolinting to `Makefile`