### PR TITLE
Remove unicode literals impport in main to prevent warning (and potential bugs)

### DIFF
--- a/important/__main__.py
+++ b/important/__main__.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import click
 import logging
 import os


### PR DESCRIPTION
Fixes #21. [Using unicode literals can inadvertently pass unicode strings to Click APIs that don't support them](http://click.pocoo.org/5/python3/#unicode-literals).