### PR TITLE
Check for files when searching for package info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
+PYTHON_VERSION := `python -c 'import sys; print(sys.version_info.major)'`
+
 all: install test lint
 
 install:
 	pip install -e .
+	@if [ "$(PYTHON_VERSION)" = "2" ]; then pip install -r python27_requirements.txt; fi
 	pip install -r dev_requirements.txt
-
 test: install
 	py.test -vv --cov=important tests/
 	important -v --requirements requirements.txt --constraints constraints.txt .

--- a/important/parse.py
+++ b/important/parse.py
@@ -147,6 +147,10 @@ def translate_requirement_to_module_names(requirement_name):
             filepath.endswith('.py')
 
     for result in search_packages_info([requirement_name]):
+        if 'files' not in result:
+            # Assume that only one module is installed in this case
+            continue
+
         # Handle modules that are installed as folders in site-packages
         folders = map(lambda filepath: os.path.dirname(filepath),
                       result['files'])

--- a/important/parse.py
+++ b/important/parse.py
@@ -147,10 +147,9 @@ def translate_requirement_to_module_names(requirement_name):
             filepath.endswith('.py')
 
     for result in search_packages_info([requirement_name]):
-        if 'files' not in result:
+        if 'files' not in result or not result['files']:
             # Assume that only one module is installed in this case
             continue
-
         # Handle modules that are installed as folders in site-packages
         folders = map(lambda filepath: os.path.dirname(filepath),
                       result['files'])

--- a/python27_requirements.txt
+++ b/python27_requirements.txt
@@ -1,0 +1,2 @@
+# Modules tested (Python 2.7 or lower)
+wsgiref  # Returns no files from search_packages

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ IMPORT_TO_PACKAGE = {
     'matplotlib': 'matplotlib',
     'cssutils': 'cssutils',
     'pylab': 'matplotlib',
-    'matplotlib.pyplot': 'matplotlib'
+    'matplotlib.pyplot': 'matplotlib',
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,12 @@ IMPORT_STATEMENT_TO_IMPORT = {
     'import cssutils': 'cssutils',
 }
 
+# Add Python 2.7 and lower tests
+if sys.version_info < (3, 0):
+    IMPORT_STATEMENT_TO_IMPORT.update({
+        'import wsgiref': 'wsgiref',
+    })
+
 IMPORT_TO_PACKAGE = {
     # package installed with differing name ('dns' folder)
     'dns': 'dnspython',
@@ -35,6 +41,12 @@ IMPORT_TO_PACKAGE = {
     'pylab': 'matplotlib',
     'matplotlib.pyplot': 'matplotlib',
 }
+
+# Add Python 2.7 and lower tests
+if sys.version_info < (3, 0):
+    IMPORT_TO_PACKAGE.update({
+        'wsgiref': 'wsgiref',
+    })
 
 
 @pytest.fixture(params=IMPORT_STATEMENT_TO_IMPORT.items())


### PR DESCRIPTION
Fixes https://github.com/cfournie/important/issues/26 by making sure that there are `files` in a found package before parsing them.

Couldn't add a test for the `wsgiref` package for Python 3 (since it's in the standard library already and this pypi package is Python 2 only).